### PR TITLE
Improve UX with menu close and auth handling

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3,7 +3,26 @@
 
 /* Reset */
 *{margin:0;padding:0;box-sizing:border-box;}
-html,body{width:100%;height:100%;font-family:'Poppins',sans-serif;background:#000;color:#fff;overflow-x:hidden;}
+:root{
+  --bg-color:#000;
+  --text-color:#fff;
+  --accent-gradient:linear-gradient(45deg,#00d2ff,#ff00ea);
+  --card-bg:rgba(255,255,255,0.05);
+  --card-border:rgba(255,255,255,0.2);
+  --input-bg:#111;
+  --btn-text:#000;
+  color-scheme: dark light;
+}
+body.light{
+  --bg-color:#fff;
+  --text-color:#000;
+  --card-bg:rgba(0,0,0,0.05);
+  --card-border:rgba(0,0,0,0.2);
+  --input-bg:#f1f1f1;
+  --btn-text:#fff;
+  color-scheme: light dark;
+}
+html,body{width:100%;height:100%;font-family:'Poppins',sans-serif;background:var(--bg-color);color:var(--text-color);overflow-x:hidden;}
 
 /* Video BG */
 .bg-video{position:fixed;top:0;left:0;width:100%;height:100%;object-fit:cover;z-index:-1;opacity:0.6;}
@@ -12,12 +31,12 @@ html,body{width:100%;height:100%;font-family:'Poppins',sans-serif;background:#00
 .navbar{display:flex;align-items:center;justify-content:space-between;padding:1rem;background:rgba(0,0,0,0.7);position:sticky;top:0;z-index:100;}
 .logo{font-size:1.8rem;font-weight:700;background:linear-gradient(45deg,#00d2ff,#ff00ea);-webkit-background-clip:text;color:transparent;text-decoration:none;}
 .nav-links{display:flex;align-items:center;}
-.nav-links a, .nav-links .btn-auth{margin-left:1rem;color:#fff;text-decoration:none;padding:.5rem 1rem;border:1px solid transparent;border-radius:4px;transition:background .3s;}
+.nav-links a, .nav-links .btn-auth{margin-left:1rem;color:var(--text-color);text-decoration:none;padding:.5rem 1rem;border:1px solid transparent;border-radius:4px;transition:background .3s;}
 .nav-links a:hover, .nav-links .btn-auth:hover{background:rgba(255,255,255,0.1);}
 
 /* Hamburger */
 .mobile-menu{display:none;background:none;border:none;flex-direction:column;gap:4px;cursor:pointer;}
-.mobile-menu span{width:25px;height:3px;background:#fff;border-radius:2px;}
+.mobile-menu span{width:25px;height:3px;background:var(--text-color);border-radius:2px;}
 @media(max-width:768px){
   .mobile-menu{display:flex;}
   .nav-links{position:absolute;top:60px;left:0;right:0;flex-direction:column;background:rgba(0,0,0,0.9);display:none;}
@@ -36,7 +55,7 @@ html,body{width:100%;height:100%;font-family:'Poppins',sans-serif;background:#00
 
 /* Features */
 .container{max-width:1000px;margin:2rem auto;padding:0 1rem;}
-.features{padding:4rem 0;background:#111;}
+.features{padding:4rem 0;background:var(--input-bg);}
 .features h2{text-align:center;font-size:2rem;margin-bottom:2rem;background:linear-gradient(45deg,#00d2ff,#ff00ea);-webkit-background-clip:text;color:transparent;}
 .feature-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1.5rem;}
 .card{background:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.2);padding:2rem;border-radius:8px;text-align:center;}
@@ -65,7 +84,7 @@ html,body{width:100%;height:100%;font-family:'Poppins',sans-serif;background:#00
   text-align:center;
 }
 .auth-form input, .auth-form select, .auth-form textarea, .plan-card, .course-card, .report-card input, .report-card textarea {
-  width:100%;margin:.75rem 0;padding:.75rem;border:none;border-radius:4px;background:#111;color:#fff;
+  width:100%;margin:.75rem 0;padding:.75rem;border:none;border-radius:4px;background:var(--input-bg);color:var(--text-color);
 }
 
 /* Courses */
@@ -113,3 +132,14 @@ html,body{width:100%;height:100%;font-family:'Poppins',sans-serif;background:#00
     grid-template-columns: 1fr;
   }
 }
+
+/* Theme toggle */
+.theme-toggle{background:none;border:1px solid var(--card-border);border-radius:4px;color:var(--text-color);margin-left:.5rem;cursor:pointer;padding:.3rem .5rem;}
+
+/* How It Works */
+.how-it-works ol{list-style:decimal inside;padding:1rem 2rem;background:var(--card-bg);border:1px solid var(--card-border);border-radius:8px;}
+.how-it-works li{margin:.5rem 0;font-size:1.1rem;}
+
+/* Error message */
+.error{color:#f66;margin-top:.5rem;font-size:.9rem;}
+

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,12 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="thaghrah - منصة عربية حديثة لبرامج مكافآت الأخطاء"/>
+  <meta property="og:title" content="thaghrah"/>
+  <meta property="og:description" content="منصة عربية لبرامج مكافآت الثغرات"/>
+  <meta property="og:image" content="/assets/og-image.png"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
   <title>thaghrah – أول منصة Bug Bounty عربية</title>
   <link rel="stylesheet" href="/css/style.css" />
 </head>
@@ -27,6 +33,7 @@
       <a href="/pages/login.html" class="btn-auth">تسجيل دخول</a>
       <a href="/pages/register.html" class="btn-auth">إنشاء حساب</a>
       <a href="?lang=en" class="lang-toggle">EN</a>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
     </nav>
   </header>
 
@@ -49,6 +56,17 @@
     </div>
   </section>
 
+  <!-- How It Works -->
+  <section class="container how-it-works">
+    <h2>كيف نعمل؟</h2>
+    <ol>
+      <li>إنشئ حسابك</li>
+      <li>اختر البرنامج المناسب</li>
+      <li>قدّم تقريرك الأمني</li>
+      <li>استلم مكافأتك</li>
+    </ol>
+  </section>
+
   <!-- Testimonials -->
   <section class="testimonials container">
     <h2>آراء المستخدمين</h2>
@@ -67,11 +85,8 @@
   <!-- Footer -->
   <footer class="footer"><p>© 2025 thaghrah. جميع الحقوق محفوظة.</p></footer>
 
-  <script>
-    // تفعيل قائمة الموبايل
-    document.getElementById('hamburger').addEventListener('click', () => {
-      document.getElementById('navLinks').classList.toggle('open');
-    });
-  </script>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/js/auth-form.js
+++ b/public/js/auth-form.js
@@ -1,0 +1,20 @@
+document.addEventListener('DOMContentLoaded',()=>{
+  const form=document.querySelector('.auth-form');
+  if(!form) return;
+  const errorEl=document.getElementById('authError');
+  form.addEventListener('submit',async e=>{
+    e.preventDefault();
+    const data=new FormData(form);
+    try{
+      const res=await fetch(form.action,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(Object.fromEntries(data)),credentials:'include'});
+      const result=await res.json();
+      if(res.ok&&result.success){
+        location.href='/';
+      }else{
+        if(errorEl){errorEl.textContent=result.message||'حدث خطأ';errorEl.hidden=false;}
+      }
+    }catch(err){
+      if(errorEl){errorEl.textContent='فشل الاتصال بالخادم';errorEl.hidden=false;}
+    }
+  });
+});

--- a/public/js/menu.js
+++ b/public/js/menu.js
@@ -1,3 +1,14 @@
-document.getElementById('hamburger').addEventListener('click', () => {
-  document.getElementById('navLinks').classList.toggle('open');
-});
+const menuBtn = document.getElementById('hamburger');
+const links = document.getElementById('navLinks');
+if(menuBtn && links){
+  menuBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    links.classList.toggle('open');
+  });
+  document.addEventListener('click', e => {
+    if(links.classList.contains('open') && !links.contains(e.target)){
+      links.classList.remove('open');
+    }
+  });
+}
+

--- a/public/js/sw-register.js
+++ b/public/js/sw-register.js
@@ -1,0 +1,7 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js').catch(() => {
+      console.error('Service worker registration failed');
+    });
+  });
+}

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,0 +1,14 @@
+const toggle = document.getElementById('themeToggle');
+const apply = mode => {
+  document.body.classList.toggle('light', mode === 'light');
+  localStorage.setItem('theme', mode);
+};
+const stored = localStorage.getItem('theme');
+const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+apply(stored || (prefersLight ? 'light' : 'dark'));
+if (toggle) {
+  toggle.addEventListener('click', () => {
+    const newMode = document.body.classList.contains('light') ? 'dark' : 'light';
+    apply(newMode);
+  });
+}

--- a/public/pages/company-dashboard.html
+++ b/public/pages/company-dashboard.html
@@ -1,8 +1,25 @@
 <!DOCTYPE html>
 <html lang="ar" dir="rtl">
-<head>…</head>
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="لوحة تحكم الشركات في thaghrah"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
+  <link rel="stylesheet" href="/css/style.css"/>
+  <title>لوحة الشركة – thaghrah</title>
+</head>
 <body>
-  <header class="navbar">…</header>
+  <header class="navbar">
+    <a href="/" class="logo">thaghrah</a>
+    <nav class="nav-links">
+      <a href="/pages/courses.html">Courses</a>
+      <a href="/pages/submit.html">Submit Bug</a>
+      <a href="/pages/hacker-dashboard.html">Hackers</a>
+      <a href="/pages/company-dashboard.html" class="active">Companies</a>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
+    </nav>
+  </header>
   <div class="container">
     <h2>لوحة التحكم – شركة</h2>
     <h3>برامجك</h3>
@@ -10,6 +27,8 @@
     <h3>التقارير الواردة</h3>
     <table id="company-reports" class="report-table"></table>
   </div>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
   <script>
     (async()=>{
       const [pRes,rRes]=await Promise.all([
@@ -27,10 +46,11 @@
         cp.appendChild(c);
       });
       const cr=document.getElementById('company-reports');
-      cr.innerHTML=`<thead><tr><th>العنوان</th><th>الباحث</th><th>الحالة</th></tr></thead>
-        <tbody>${reports.map(r=>`
-          <tr><td>${r.title}</td><td>${r.hacker}</td><td>${r.status}</td></tr>`).join('')}</tbody>`;
+      cr.innerHTML=`<thead><tr><th>العنوان</th><th>الباحث</th><th>الحالة</th></tr></thead>`+
+        `<tbody>${reports.map(r=>`+
+          `<tr><td>${r.title}</td><td>${r.hacker}</td><td>${r.status}</td></tr>`).join('')}</tbody>`;
     })();
   </script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/pages/courses.html
+++ b/public/pages/courses.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="دورات الأمن السيبراني على منصة thaghrah"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
   <title>الدورات – thaghrah</title>
   <link rel="stylesheet" href="/css/style.css"/>
 </head>
@@ -16,6 +19,7 @@
       <a href="/pages/login.html">تسجيل دخول</a>
       <a href="/pages/register.html">إنشاء حساب</a>
       <a href="?lang=en" class="lang-toggle">EN</a>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
     </nav>
   </header>
 
@@ -36,5 +40,8 @@
   </main>
 
   <footer class="footer"><p>© 2025 thaghrah.</p></footer>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/pages/hacker-dashboard.html
+++ b/public/pages/hacker-dashboard.html
@@ -1,14 +1,33 @@
 <!DOCTYPE html>
 <html lang="ar" dir="rtl">
-<head>…</head>
+<head>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="لوحة تحكم الباحثين في thaghrah"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
+  <link rel="stylesheet" href="/css/style.css"/>
+  <title>لوحة الباحث – thaghrah</title>
+</head>
 <body>
-  <header class="navbar">…</header>
+  <header class="navbar">
+    <a href="/" class="logo">thaghrah</a>
+    <nav class="nav-links">
+      <a href="/pages/courses.html">Courses</a>
+      <a href="/pages/submit.html">Submit Bug</a>
+      <a href="/pages/hacker-dashboard.html" class="active">Hackers</a>
+      <a href="/pages/company-dashboard.html">Companies</a>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
+    </nav>
+  </header>
   <div class="container">
     <h2>لوحة التحكم – باحث</h2>
     <div id="stats" class="feature-cards"></div>
     <h3>تقاريرك الأخيرة</h3>
     <table id="reports-table" class="report-table"></table>
   </div>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
   <script>
     (async () => {
       const res = await fetch('/api/hacker/reports');
@@ -22,15 +41,11 @@
         sc.appendChild(card);
       });
       const tbl = document.getElementById('reports-table');
-      tbl.innerHTML = `<thead><tr><th>العنوان</th><th>التاريخ</th><th>الحالة</th><th>المكافأة</th></tr></thead>
-        <tbody>${reports.map(r=>`
-          <tr>
-            <td>${r.title}</td>
-            <td>${new Date(r.createdAt).toLocaleDateString()}</td>
-            <td>${r.status}</td>
-            <td>${r.reward}</td>
-          </tr>`).join('')}</tbody>`;
+      tbl.innerHTML = `<thead><tr><th>العنوان</th><th>التاريخ</th><th>الحالة</th><th>المكافأة</th></tr></thead>`+
+        `<tbody>${reports.map(r=>`+
+          `<tr><td>${r.title}</td><td>${new Date(r.createdAt).toLocaleDateString()}</td><td>${r.status}</td><td>${r.reward}</td></tr>`).join('')}</tbody>`;
     })();
   </script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/pages/login.html
+++ b/public/pages/login.html
@@ -3,10 +3,14 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="تسجيل دخول لمنصة thaghrah"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
   <title>تسجيل دخول – thaghrah</title>
   <link rel="stylesheet" href="/css/style.css"/>
 </head>
 <body class="auth-page">
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
   <div class="auth-card">
     <h2>تسجيل دخول</h2>
     <form action="/auth/login" method="POST" class="auth-form">
@@ -14,13 +18,18 @@
       <input type="password" name="password" placeholder="كلمة المرور" required/>
       <button type="submit" class="btn-primary">دخول</button>
     </form>
-    <div class="social-wrap">
+    <p id="authError" class="error" hidden></p>
+  <div class="social-wrap">
       <a href="/auth/google"   class="btn-social google">Google</a>
       <a href="/auth/facebook" class="btn-social facebook">Facebook</a>
       <a href="/auth/github"   class="btn-social github">GitHub</a>
       <a href="/auth/apple"    class="btn-social apple">Apple</a>
-    </div>
-    <p>ليس لديك حساب؟ <a href="register.html">إنشاء حساب</a></p>
   </div>
+  <p>ليس لديك حساب؟ <a href="register.html">إنشاء حساب</a></p>
+  </div>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
+  <script src="/js/auth-form.js"></script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/pages/payment.html
+++ b/public/pages/payment.html
@@ -1,15 +1,31 @@
 <!DOCTYPE html>
 <html lang="ar" dir="rtl">
 <head>
-  <meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>الدفع – thaghrah</title>
+  <meta charset="UTF-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <meta name="description" content="صفحة الدفع في thaghrah"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
   <link rel="stylesheet" href="/css/style.css"/>
+  <title>الدفع – thaghrah</title>
 </head>
 <body>
-  <header class="navbar">…</header>
+  <header class="navbar">
+    <a href="/" class="logo">thaghrah</a>
+    <nav class="nav-links">
+      <a href="/pages/courses.html">Courses</a>
+      <a href="/pages/submit.html">Submit Bug</a>
+      <a href="/pages/login.html">تسجيل دخول</a>
+      <a href="/pages/register.html">إنشاء حساب</a>
+      <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
+    </nav>
+  </header>
   <div class="container">
     <h2>الدفع</h2>
     <p>ستُوجه إلى صفحة الدفع الآمنة…</p>
   </div>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/pages/programs.html
+++ b/public/pages/programs.html
@@ -21,3 +21,5 @@
     });
   })();
 </script>
+<script src="/js/theme.js"></script>
+<script src="/js/menu.js"></script>

--- a/public/pages/register.html
+++ b/public/pages/register.html
@@ -3,13 +3,17 @@
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="description" content="إنشاء حساب جديد في منصة thaghrah"/>
+  <link rel="manifest" href="/manifest.json"/>
+  <meta name="theme-color" content="#000000"/>
   <title>إنشاء حساب – thaghrah</title>
   <link rel="stylesheet" href="/css/style.css"/>
 </head>
 <body class="auth-page">
+  <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">🌓</button>
   <div class="auth-card">
     <h2>إنشاء حساب</h2>
-    <form action="/auth/register" method="POST">
+    <form action="/auth/register" method="POST" class="auth-form">
       <div class="form-group">
         <input type="email"    name="email"    placeholder=" " required/>
         <label>البريد الإلكتروني</label>
@@ -28,6 +32,7 @@
       </div>
       <button type="submit" class="btn-primary">سجّل</button>
     </form>
+    <p id="authError" class="error" hidden></p>
     <div class="social-wrap">
       <a href="/auth/google"  class="social-btn google">Google</a>
       <a href="/auth/facebook"class="social-btn facebook">Facebook</a>
@@ -36,5 +41,9 @@
     </div>
     <p>لديك حساب؟ <a href="login.html">تسجيل دخول</a></p>
   </div>
+  <script src="/js/theme.js"></script>
+  <script src="/js/menu.js"></script>
+  <script src="/js/auth-form.js"></script>
+  <script src="/js/sw-register.js"></script>
 </body>
 </html>

--- a/public/pages/submit.html
+++ b/public/pages/submit.html
@@ -46,3 +46,6 @@
     }
   });
 </script>
+<script src="/js/theme.js"></script>
+<script src="/js/menu.js"></script>
+<script src="/js/sw-register.js"></script>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,9 +1,24 @@
-service-worker.js
 
 self.addEventListener('install', event => {
   event.waitUntil(
     caches.open('thaghrah-v1').then(cache =>
-      cache.addAll(['/', '/css/style.css', '/assets/cyber-bg.mp4'])
+      cache.addAll([
+        '/',
+        '/css/style.css',
+        '/js/theme.js',
+        '/js/menu.js',
+        '/js/auth-form.js',
+        '/js/sw-register.js',
+        '/assets/cyber-bg.mp4'
+      ])
+    )
+  );
+});
+self.addEventListener('activate', event => {
+  const current = 'thaghrah-v1';
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== current).map(k => caches.delete(k)))
     )
   );
 });


### PR DESCRIPTION
## Summary
- add Open Graph tags and new "How It Works" section
- close nav menu on outside click via `menu.js`
- add auth-form handling script and display error messages
- include menu/auth scripts across pages
- implement basic PWA support with service worker
- theme enhancements with `color-scheme` property

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861047177bc832985c8123f75eb87f7